### PR TITLE
Missed naming fixes

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,12 +1,12 @@
 # Infrastructure as Code
 
-This directory contains Terraform configuration for the closurebot-on511 project's AWS infrastructure.
+This directory contains Terraform configuration for the closurebot-ab511 project's AWS infrastructure.
 
 ## What it creates
 
 - **ECR Repositories**: Two ECR repos for container images
-  - `closurebot-on511-prod`: Production images (master branch)
-  - `closurebot-on511-dev`: Development images (develop branch)
+  - `closurebot-ab511-prod`: Production images (master branch)
+  - `closurebot-ab511-dev`: Development images (develop branch)
 - **Lifecycle Policies**: Automatic cleanup of old images
   - Keeps latest-* images safe
   - Deletes commit-tagged images older than 2 days
@@ -37,7 +37,7 @@ terraform output
 The configuration auto-detects the project name from the GitHub repository. You can override with:
 
 ```bash
-terraform apply -var="project_name=closurebot-on511" -var="github_repo=username/closurebot-on511"
+terraform apply -var="project_name=closurebot-ab511" -var="github_repo=username/closurebot-ab511"
 ```
 
 ## Outputs

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -17,10 +17,10 @@ locals {
   # Try to get GitHub repo from environment variable, fall back to variable
   github_repo = var.github_repo != "" ? var.github_repo : (try(getenv("GITHUB_REPOSITORY"), ""))
   
-  # Extract project name from GitHub repo (e.g., "username/closurebot-on511" -> "closurebot-on511")
+  # Extract project name from GitHub repo (e.g., "username/closurebot-ab511" -> "closurebot-ab511")
   # If no repo provided, use a default based on directory name
   detected_project = var.project_name != "" ? var.project_name : (
-    local.github_repo != "" ? split("/", local.github_repo)[1] : "closurebot-on511"
+    local.github_repo != "" ? split("/", local.github_repo)[1] : "closurebot-ab511"
   )
   project_name     = local.detected_project
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -2,7 +2,7 @@
 # Auto-detects project name from GitHub repository name
 
 variable "project_name" {
-  description = "Name of the project (e.g., closurebot-on511). Auto-detected from GITHUB_REPOSITORY if not provided."
+  description = "Name of the project (e.g., closurebot-ab511). Auto-detected from GITHUB_REPOSITORY if not provided."
   type        = string
   default     = ""
 }
@@ -14,7 +14,7 @@ variable "aws_region" {
 }
 
 variable "github_repo" {
-  description = "GitHub repository in format owner/repo (e.g., username/closurebot-on511). Auto-detected from GITHUB_REPOSITORY env var if not provided."
+  description = "GitHub repository in format owner/repo (e.g., username/closurebot-ab511). Auto-detected from GITHUB_REPOSITORY env var if not provided."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
- Updated default project name from closurebot-on511 to closurebot-ab511
- Updated variable descriptions to use correct project naming
- Updated README documentation with correct repository names
- All infrastructure now defaults to closurebot-ab511 naming convention